### PR TITLE
Makes component fixed to the top / bottom of the page like the app bar

### DIFF
--- a/src/components/Ads/manifest.json
+++ b/src/components/Ads/manifest.json
@@ -65,7 +65,7 @@
       "name": "placeholder",
       "displayName": "Show placeholder ad on web preview",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "helpText": "See how this component fits the design of your app in the preview.  Disable to hide placeholder from Share URL and PWA."
     }
   ]


### PR DESCRIPTION
## General Idea

* Right now the admob component scrolls with the content of a page
* Most of the admob component examples I've seen (both Adalo apps and others) have the admob banner fixed to the bottom of the screen, not scrolling
* This PR creates a similar behavior with our component

## Additional

* Sets "Show placeholder ad" to true by default, so the ads are visible in preview. This really tripped me up when testing.

## Testing

* Have not tested on mobile builds, which we should test as I've only tested with the fake ads