### PR TITLE
Changed script to work with RN 63 upgrade on iOS

### DIFF
--- a/scripts/install_ios.sh
+++ b/scripts/install_ios.sh
@@ -25,11 +25,15 @@ done
 # Podfile
 cd ios
 
-sed -i.bak '/use_native_modules/a\
-  pod "Google-Mobile-Ads-SDK" 
-' Podfile
-
-pod install --repo-update
+if ! grep -q "marketplace" "Podfile"; then
+  sed -i.bak '/marketplace/a\
+  \  pod "Google-Mobile-Ads-SDK" 
+  ' Podfile
+else
+  sed -i.bak '/RNCPushNotificationIOS/a\
+  \  pod "Google-Mobile-Ads-SDK" 
+  ' Podfile
+fi
 
 # AppDelegate.m
 cd $name


### PR DESCRIPTION
The install script modified the podfile in a way that made it incompatible with the RN upgrade. The script will still work on the old version, but I modified it to work with the upgrade.