### PR TITLE
tweaked how framework gets copied. Fixed double-slash issue, and checks for the directory existing before executing cp command.

### DIFF
--- a/scripts/install_ios.sh
+++ b/scripts/install_ios.sh
@@ -18,7 +18,14 @@ unzip googlemobileadssdkios.zip
 for direct in */; do
   if [[ $direct = Google* ]];
   then
-    cp -R $direct/GoogleMobileAds.framework ios/GoogleMobileAds.framework
+    if [[ -d $(echo $direct/GoogleMobileAds.xcframework | tr -s /) ]]; then
+      echo "Moving XC Framework into the correct folder."
+      cp -R $(echo $direct/GoogleMobileAds.xcframework | tr -s /) ios/GoogleMobileAds.xcframework
+    fi;
+    if [[ -d "$(echo $direct/GoogleMobileAds.framework | tr -s /)" ]]; then
+      echo "Moving Framework into the correct folder."
+      cp -R $(echo $direct/GoogleMobileAds.framework | tr -s /) ios/GoogleMobileAds.framework
+    fi;
   fi;
 done
 


### PR DESCRIPTION
### Problem
First, for some reason, the $direct variable had an extra slash in it, causing the `cp` command to fail.
Second, it seems like Google may have changed the directory structure, changing the directory `GoogleMobileAds.framework` to `GoogleMobileAds.xcframework`.

### Solution
First, I piped the string into `tr` to trim the extra slash, if it exists.
Next, I added an if statement to test for both directory formats and copy the one that exists.