### PR TITLE
Fix AdMob Crashing Apps Built With Android 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adalo/ads",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "author": "Adalo",
   "license": "MIT",
   "main": "index.js",

--- a/scripts/install_android.sh
+++ b/scripts/install_android.sh
@@ -23,7 +23,8 @@ implementation "com.android.support:multidex:1.0.3"\
 implementation "com.google.android.gms:play-services-ads:19.6.0"\
 implementation "com.google.android.gms:play-services-base:17.5.0"\
 implementation "com.google.firebase:firebase-core:18.0.0"\
-implementation "com.google.firebase:firebase-messaging:21.0.0"
+implementation "com.google.firebase:firebase-messaging:21.0.0"\
+implementation "androidx.work:work-runtime-ktx:2.7.0-alpha05"
 ' build.gradle
 
 # AndroidManifest


### PR DESCRIPTION
AdMob was causing apps built on Android 12 to crash. This was a known issue according to the [release notes](https://developers.google.com/admob/android/rel-notes).

The fix in those release notes did not work, but the fix suggested in this StackOverflow [post](https://stackoverflow.com/questions/67045607/how-to-resolve-missing-pendingintent-mutability-flag-lint-warning-in-android-a) did.